### PR TITLE
forcefully purge unmanaged files and directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## Changed
+- Purge directories recursively
 - Update PDK to 2.7.1
 - Bump OS and Puppet dependencies
 - Minor improvement to unit test
+
+### Fixes
+- Frequent service restarts because directories cannot be purged
 
 ## [3.1.0] - 2020-09-12
 This release now uses PDK and increases dependency compatibility.

--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -7,6 +7,7 @@ class dovecot::configuration inherits dovecot {
       path    => $dovecot::config_path,
       recurse => true,
       purge   => true,
+      force   => true,
       before  => File["${dovecot::config_path}/conf.d"]
     }
   }


### PR DESCRIPTION
Currently the module is unable to purge the config directory if it contains sub-directories:

```
Notice: /Stage[main]/Dovecot::Configuration/File[/usr/local/etc/dovecot/example-config]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Dovecot::Configuration/File[/usr/local/etc/dovecot/example-config]/ensure: removed (corrective)
Notice: /Stage[main]/Dovecot::Configuration/File[/usr/local/etc/dovecot/example-config/conf.d]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Dovecot::Configuration/File[/usr/local/etc/dovecot/example-config/conf.d]/ensure: removed (corrective)
```

This leads to frequent restarts of the dovecot service:

```
Info: Class[Dovecot::Configuration]: Scheduling refresh of Class[Dovecot::Service]
Info: Class[Dovecot::Service]: Scheduling refresh of Service[dovecot]
Notice: /Stage[main]/Dovecot::Service/Service[dovecot]: Triggered 'refresh' from 1 event
```

Setting the `force => true` attribute fixes this issue.