### PR TITLE
Minimal support for Dovecot 2.4

### DIFF
--- a/manifests/configentry.pp
+++ b/manifests/configentry.pp
@@ -57,9 +57,11 @@ define dovecot::configentry (
   # now for the value itself
   $indent = sprintf("%${$depth * 2}s", '')
   $section = join($rsections, ' 03 ')
+  # Put dovecot_config_version first in the config file, for Dovecot 2.4.
+  $priority = if $sections == [] and $key == 'dovecot_config_version' { '01' } else { '02' }
 
   if ($comment) {
-    concat::fragment { "dovecot ${file} config ${section} 02 ${key} 01 comment":
+    concat::fragment { "dovecot ${file} config ${section} ${priority} ${key} 01 comment":
       target  => $file,
       content => join(suffix(prefix(split($comment, '\n'), "${indent}# "), "\n")),
     }
@@ -77,7 +79,7 @@ define dovecot::configentry (
     }
     default: {
       $printed_value = dovecot::print_config_value($value)
-      concat::fragment { "dovecot ${file} config ${section} 02 ${key} 02":
+      concat::fragment { "dovecot ${file} config ${section} ${priority} ${key} 02":
         target  => $file,
         content => "${indent}${key} = ${printed_value}\n",
       }

--- a/spec/defines/configentry_spec.rb
+++ b/spec/defines/configentry_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe 'dovecot::configentry' do
+  let(:pre_condition) do
+    <<-EOS
+      class { 'dovecot':
+        package_name        => ['dovecot-core'],
+        poolmon_config_file => 'foo',
+      }
+    EOS
+  end
+  let(:title) { 'foo' }
+  let(:default_params) do
+    {
+      'file'    => '/dovecot.conf',
+      'key'     => 'foo',
+      'value'   => 'bar',
+      'comment' => 'Comment.'
+    }
+  end
+
+  context 'with key=dovecot_config_version' do
+    let(:params) do default_params.merge({ 'key' => 'dovecot_config_version' }) end
+
+    it 'is output at the top of the config file' do
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 01 dovecot_config_version 01 comment')
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 01 dovecot_config_version 02')
+    end
+  end
+
+  context 'with a top-level key' do
+    let(:params) do default_params.merge({ 'key' => 'foo' }) end
+
+    it 'gets ordered second' do
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 02 foo 01 comment')
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 02 foo 02')
+    end
+  end
+
+  context 'with a key under a section' do
+    let(:params) do default_params.merge({ 'key' => 'foo', 'sections' => ['s1'] }) end
+
+    it 'gets ordered next' do
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 03 s1 01 section start')
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 03 s1 02 foo 01 comment')
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 03 s1 02 foo 02')
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 03 s1 05 section end')
+    end
+  end
+
+  context 'with an !include' do
+    let(:params) do default_params.merge({ 'key' => '!include' }) end
+
+    it 'gets ordered last' do
+      is_expected.to contain_concat__fragment('dovecot /dovecot.conf config / 04 !include bar')
+    end
+
+    it 'keeps the comment next to it' do
+      pending('comments on !include are currently not supported')
+      is_expected.not_to contain_concat__fragment('dovecot /dovecot.conf config / 02 !include 01 comment')
+      is_expected.to     contain_concat__fragment('dovecot /dovecot.conf config / 04 !include bar comment')
+    end
+  end
+end


### PR DESCRIPTION
Put dovecot_config_version first in the config file. This allows using the module with Dovecot 2.4.1.

I forgot the specifics (this was a year ago), so I don't know if it's enough to close #43.